### PR TITLE
회원 탈퇴 API 

### DIFF
--- a/src/applications/adapter/in-bound/user.controller.ts
+++ b/src/applications/adapter/in-bound/user.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   UseFilters,
   UseGuards,
+  Delete,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -96,5 +97,25 @@ export class UserController {
     @Body() dto: RequestUpdateUserDto,
   ): Promise<void> {
     await this.userServicePort.updateUser(user_id, dto);
+  }
+
+  @Delete()
+  @UseGuards(JwtAuthGuard)
+  @UseFilters(JwtExceptionFilter)
+  @ApiOperation({
+    summary: '회원 탈퇴 api',
+    description: '회원 탈퇴 api',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '성공',
+    type: ResponseGetUserIdDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '실패(잘못된 요청)',
+  })
+  async deleteUser(@User() user_id: number): Promise<void> {
+    await this.userServicePort.deleteUser(user_id);
   }
 }

--- a/src/applications/adapter/in-bound/user.controller.ts
+++ b/src/applications/adapter/in-bound/user.controller.ts
@@ -8,6 +8,7 @@ import {
   UseFilters,
   UseGuards,
   Delete,
+  HttpCode,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -107,7 +108,7 @@ export class UserController {
     description: '회원 탈퇴 api',
   })
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: '성공',
     type: ResponseGetUserIdDto,
   })
@@ -115,6 +116,7 @@ export class UserController {
     status: 400,
     description: '실패(잘못된 요청)',
   })
+  @HttpCode(204)
   async deleteUser(@User() user_id: number): Promise<void> {
     await this.userServicePort.deleteUser(user_id);
   }

--- a/src/applications/adapter/out-bound/user.repository.ts
+++ b/src/applications/adapter/out-bound/user.repository.ts
@@ -28,4 +28,8 @@ export class UserRepository implements UserRepositoryPort {
   async save(user: UserInterface): Promise<void> {
     await this.userRepository.save(user);
   }
+
+  async delete(user_id: number): Promise<void> {
+    await this.userRepository.softDelete(user_id); 
+  }
 }

--- a/src/applications/port/in-bound/user.service.port.ts
+++ b/src/applications/port/in-bound/user.service.port.ts
@@ -15,4 +15,5 @@ export abstract class UserServicePort {
   ) => Promise<ResponseGetUserPhoneNumberDto>;
   saveUser: (dto: RequestSaveUserDto) => Promise<void>;
   updateUser: (user_id: number, dto: RequestUpdateUserDto) => Promise<void>;
+  deleteUser: (user_id: number) => Promise<void>;
 }

--- a/src/applications/port/out-bound/user.repository.port.ts
+++ b/src/applications/port/out-bound/user.repository.port.ts
@@ -8,4 +8,5 @@ export abstract class UserRepositoryPort {
     options: FindOneOptions<UserEntity>,
   ) => Promise<ResponseUserFindOneDto>;
   save: (user: UserInterface) => Promise<void>;
+  delete: (user_id: number) => Promise<void>;
 }

--- a/src/applications/use-case/user.service.ts
+++ b/src/applications/use-case/user.service.ts
@@ -173,7 +173,7 @@ export class UserService implements UserServicePort {
   ): Promise<ResponseGetUserPhoneNumberDto> {
     const user = await this.userRepositoryPort.findOne({
       where: { phone_number: phone_number },
-      select: ['phone_number'],
+      select: ['phone_number', 'id'],
     });
 
     if (user) {

--- a/src/applications/use-case/user.service.ts
+++ b/src/applications/use-case/user.service.ts
@@ -243,4 +243,8 @@ export class UserService implements UserServicePort {
     };
     await this.userRepositoryPort.save({ ...user, status: UserStatus.PENDING });
   }
+
+  async deleteUser(user_id: number): Promise<void> {
+    await this.userRepositoryPort.delete(user_id);
+  }
 }


### PR DESCRIPTION
### 요구 사항
- 기능: 회원 탈퇴 API

### 테스트 완료 여부
- [x] 테스트 완료

### 이미지
- 레포지토리의 주석 설명
![스크린샷 2025-02-14 125300](https://github.com/user-attachments/assets/eeb04ffd-e8ca-4590-9653-431d0a643152)
- userService에서 수정한 부분
![스크린샷 2025-02-14 125419](https://github.com/user-attachments/assets/d9993b59-e6a6-4825-ac08-54c19bc42203)

### 할 말
- 일단 API 면세서를 기준으로 만들었습니다. 면세서가 변경되면 수정할 예정입니다
- deleted_at의 값이 null이 아니면 따로 설정을 안넣어주는 이상 조회가 안된다네요
- jwt를 생성시 user_id를 포함하고 있지 않아 수정했습니다.
